### PR TITLE
Update poppler to version 24.08.0

### DIFF
--- a/com.github.arminstraub.krop.metainfo.xml
+++ b/com.github.arminstraub.krop.metainfo.xml
@@ -32,6 +32,15 @@
   <update_contact>nbenitezl_AT_gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="0.6.0.fl1" date="2024-08-10">
+    <description>
+      <ul>
+        <li>Update Poppler to 24.08.0</li>
+        <li>Change build process from calling deprecated setup.py to using "pip3 install"</li>
+        <li>Remove unnecessary xdg-dirs permissions as they are now handled via file system portal</li>
+      </ul>
+    </description>
+    </release>
     <release version="0.6.0" date="2020-06-09">
     <description>0.6.0 release</description>
     <url>https://github.com/arminstraub/krop/releases/tag/v0.6.0</url>

--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -81,7 +81,7 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm644 krop.svg /app/share/icons/hicolor/scalable/apps/com.github.arminstraub.krop.svg
-      - python3 setup.py install --prefix=/app --root=/
+      - pip3 install --prefix=/app .
     post-install:
       - cp krop.desktop com.github.arminstraub.krop.desktop
       - desktop-file-edit --set-key="Icon" --set-value="com.github.arminstraub.krop" com.github.arminstraub.krop.desktop

--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -56,8 +56,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://poppler.freedesktop.org/poppler-23.12.0.tar.xz
-        sha256: beba398c9d37a9b6d02486496635e08f1df3d437cfe61dab2593f47c4d14cdbb
+        url: https://poppler.freedesktop.org/poppler-24.01.0.tar.xz
+        sha256: c7def693a7a492830f49d497a80cc6b9c85cb57b15e9be2d2d615153b79cae08
         x-checker-data:
           type: anitya
           project-id: 3686

--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -56,8 +56,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://poppler.freedesktop.org/poppler-24.01.0.tar.xz
-        sha256: c7def693a7a492830f49d497a80cc6b9c85cb57b15e9be2d2d615153b79cae08
+        url: https://poppler.freedesktop.org/poppler-24.02.0.tar.xz
+        sha256: 19187a3fdd05f33e7d604c4799c183de5ca0118640c88b370ddcf3136343222e
         x-checker-data:
           type: anitya
           project-id: 3686

--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -56,12 +56,12 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://poppler.freedesktop.org/poppler-24.02.0.tar.xz
-        sha256: 19187a3fdd05f33e7d604c4799c183de5ca0118640c88b370ddcf3136343222e
-        x-checker-data:
-          type: anitya
-          project-id: 3686
-          url-template: https://poppler.freedesktop.org/poppler-${version}.tar.xz
+        url: https://poppler.freedesktop.org/poppler-24.08.0.tar.xz
+        sha256: 97453fbddf0c9a9eafa0ea45ac710d3d49bcf23a62e864585385d3c0b4403174
+        #x-checker-data:
+        #  type: anitya
+        #  project-id: 3686
+        #  url-template: https://poppler.freedesktop.org/poppler-${version}.tar.xz
 
   - name: python-poppler-qt5
     buildsystem: simple

--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -61,8 +61,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://poppler.freedesktop.org/poppler-23.11.0.tar.xz
-        sha256: f99cca6799cb9cb6c92fc1e0eb78547b611cb733750ab7cb047cb0e6c246539c
+        url: https://poppler.freedesktop.org/poppler-23.12.0.tar.xz
+        sha256: beba398c9d37a9b6d02486496635e08f1df3d437cfe61dab2593f47c4d14cdbb
 
   - name: python-poppler-qt5
     buildsystem: simple

--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -63,6 +63,10 @@ modules:
       - type: archive
         url: https://poppler.freedesktop.org/poppler-23.12.0.tar.xz
         sha256: beba398c9d37a9b6d02486496635e08f1df3d437cfe61dab2593f47c4d14cdbb
+        x-checker-data:
+          type: anitya
+          project-id: 3686
+          url-template: https://poppler.freedesktop.org/poppler-${version}.tar.xz
 
   - name: python-poppler-qt5
     buildsystem: simple

--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -16,11 +16,6 @@ build-options:
 command: krop
 
 finish-args:
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=xdg-music
-  - --filesystem=/run/media
-  - --filesystem=/media
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland


### PR DESCRIPTION
This PR:

- Updates poppler to 24.08.0
- Changes the build process for krop from deprecated calling setup.py directly to using "pip3 install"
- Removes unnecessary file system permissions