### PR TITLE
Update runtime to 6.10

### DIFF
--- a/com.github.arminstraub.krop.yaml
+++ b/com.github.arminstraub.krop.yaml
@@ -1,9 +1,9 @@
 app-id: com.github.arminstraub.krop
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
-base-version: '6.9'
+base-version: '6.10'
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 build-options:


### PR DESCRIPTION
Because of `com.riverbankcomputing.PyQt.BaseApp` version 6.9 has been marked as EOL.